### PR TITLE
DtoDef annotation inheritance

### DIFF
--- a/processor/src/main/kotlin/com/marcode/kdto/generator/DTOGenerator.kt
+++ b/processor/src/main/kotlin/com/marcode/kdto/generator/DTOGenerator.kt
@@ -4,6 +4,7 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.AnnotationUseSiteTarget
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.marcode.kdto.processor.data.AnnotationCollection
 import com.marcode.kdto.processor.data.DtoDeclaration
 import com.marcode.kdto.util.getFormattedValue
 import com.marcode.kdto.util.toTypeName
@@ -141,7 +142,17 @@ internal class DTOGenerator(
         fileSpec: FileSpec.Builder,
         classSpec: TypeSpec.Builder,
     ) {
-        classAnnotations.forEach { annotation ->
+        val sourceClassAnnotations = when (annotationCollection) {
+            is AnnotationCollection.DtoCollection -> annotationCollection.classAnnotations
+            is AnnotationCollection.DtoDefCollection -> annotationCollection.sourceClassAnnotations
+        }
+        val dtoDefinitionAnnotations = when (annotationCollection) {
+            is AnnotationCollection.DtoDefCollection -> annotationCollection.dtoDefinitionAnnotations
+            else -> emptyList()
+        }
+        logger.logging("Source class annotations: ${sourceClassAnnotations.joinToString { it.shortName.asString() }}")
+        logger.logging("DTO definition annotations: ${dtoDefinitionAnnotations.joinToString { it.shortName.asString() }}")
+        (sourceClassAnnotations + dtoDefinitionAnnotations).forEach { annotation ->
             val annotationDeclaration = annotation.annotationType.resolve().declaration
             val annotationClassName =
                 ClassName(annotationDeclaration.packageName.asString(), annotationDeclaration.simpleName.asString())

--- a/processor/src/main/kotlin/com/marcode/kdto/processor/DTOAnnotationProcessor.kt
+++ b/processor/src/main/kotlin/com/marcode/kdto/processor/DTOAnnotationProcessor.kt
@@ -9,6 +9,7 @@ import com.google.devtools.ksp.symbol.KSValueArgument
 import com.marcode.kdto.annotations.Dto
 import com.marcode.kdto.annotations.DtoSpec
 import com.marcode.kdto.annotations.exceptions.PropertyNotFoundException
+import com.marcode.kdto.processor.data.AnnotationCollection
 import com.marcode.kdto.processor.data.DtoDeclaration
 import com.marcode.kdto.processor.data.DtoProperty
 import com.marcode.kdto.util.getArgument
@@ -49,7 +50,7 @@ internal class DTOAnnotationProcessor(
                 includedProperties = properties.map { property ->
                     DtoProperty(property, propertyExistsInSourceClass = true, includeSourceAnnotations = dtoSpec.includeAnnotations)
                 }.toList(),
-                classAnnotations = annotations
+                annotationCollection = AnnotationCollection.DtoCollection(annotations)
             )
         }
     }

--- a/processor/src/main/kotlin/com/marcode/kdto/processor/data/DtoDeclaration.kt
+++ b/processor/src/main/kotlin/com/marcode/kdto/processor/data/DtoDeclaration.kt
@@ -1,12 +1,16 @@
 package com.marcode.kdto.processor.data
 
 import com.google.devtools.ksp.symbol.KSAnnotation
-import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
 internal data class DtoDeclaration(
     val packageName: String,
     val originalClassName: String,
     val dtoName: String,
     val includedProperties: List<DtoProperty>,
-    val classAnnotations: List<KSAnnotation>
+    val annotationCollection: AnnotationCollection
 )
+
+internal sealed interface AnnotationCollection {
+    data class DtoCollection(val classAnnotations: List<KSAnnotation>): AnnotationCollection
+    data class DtoDefCollection(val sourceClassAnnotations: List<KSAnnotation>, val dtoDefinitionAnnotations: List<KSAnnotation>): AnnotationCollection
+}


### PR DESCRIPTION
Previously, only @DtoDef annotation was processed from the definition 
interface, causing other annotations to be ignored in the generated DTO.
Now all interface annotations are correctly inherited by the generated class.